### PR TITLE
Hot fix: addressing bugs related to write protect GPIO pin not being released.

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,9 @@ The `tests/test_e2e_hardware.py` suite runs against a real EEPROM chip over I2C.
    sudo dtoverlay i2c-gpio i2c_gpio_sda=0 i2c_gpio_scl=1 bus=9
    ```
 3. EEPROM tools installed (eepmake, eepdump, eepflash.sh) — see [Prerequisites](#prerequisites)
-4. Development dependencies:
+4. Development dependencies with GPIO support:
    ```bash
-   pip install -e ".[dev]"
+   pip install -e ".[dev,gpio]"
    ```
 
 #### Running hardware tests

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ A valid EEPROM must have a non-zero `product_uuid` and a `serial_number` in its 
 # Install in development mode with all dev tools
 pip install -e ".[dev]"
 
-# Run tests
+# Run tests (unit tests only — no hardware required)
 pytest tests/ -v
 
 # Run with coverage
@@ -247,6 +247,51 @@ ruff check src/ tests/
 
 # Type check
 mypy src/rpi_eeprom/
+```
+
+### Hardware end-to-end tests
+
+The `tests/test_e2e_hardware.py` suite runs against a real EEPROM chip over I2C. These tests are **skipped by default** and must be opted into explicitly.
+
+#### Prerequisites
+
+1. A Raspberry Pi with an EEPROM-equipped HAT connected
+2. I2C overlay loaded:
+   ```bash
+   sudo dtoverlay i2c-gpio i2c_gpio_sda=0 i2c_gpio_scl=1 bus=9
+   ```
+3. EEPROM tools installed (eepmake, eepdump, eepflash.sh) — see [Prerequisites](#prerequisites)
+4. Development dependencies:
+   ```bash
+   pip install -e ".[dev]"
+   ```
+
+#### Running hardware tests
+
+```bash
+# Run all hardware tests (requires sudo for I2C access)
+sudo pytest tests/test_e2e_hardware.py -v -m hardware
+
+# Run a specific hardware test
+sudo pytest tests/test_e2e_hardware.py -v -m hardware -k "test_full_lifecycle"
+
+# Run both unit and hardware tests together
+sudo pytest tests/ -v -m ""
+```
+
+> **Warning:** Hardware tests **write to and erase the EEPROM**. Any existing data on the chip will be overwritten. The test suite resets the EEPROM to a blank state at the end of the full lifecycle test. If tests are interrupted, the EEPROM may be left in a partially written state.
+
+#### Custom hardware configuration
+
+The tests use the default `EEPROMConfig` (bus=9, address=0x50, model=24c32). If your hardware differs, edit the `_HW_CONFIG` variable at the top of `tests/test_e2e_hardware.py`:
+
+```python
+_HW_CONFIG = EEPROMConfig(
+    model="24c64",
+    i2c_bus=1,
+    i2c_address=0x51,
+    write_protect_pin=17,
+)
 ```
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,10 @@ include = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+markers = [
+    "hardware: end-to-end tests that require a physical EEPROM on I2C (run with: sudo pytest -m hardware)",
+]
+addopts = "-m 'not hardware'"
 
 [tool.ruff]
 src = ["src", "tests"]

--- a/src/rpi_eeprom/_eeprom.py
+++ b/src/rpi_eeprom/_eeprom.py
@@ -197,9 +197,13 @@ class EEPROM:
         data_files = self._prepare_custom_data_files(custom_data)
 
         try:
-            self.reset()
-            image = self._make_image(template, data_files)
-            self._eepflash_write(image)
+            self._write_protect.disable()
+            try:
+                self._blank_and_verify()
+                image = self._make_image(template, data_files)
+                self._eepflash_write(image)
+            finally:
+                self._write_protect.enable()
             logger.info("EEPROM write completed successfully")
         except EEPROMWriteError:
             raise
@@ -269,7 +273,7 @@ class EEPROM:
             image = self._make_image(stripped_dump, data_files)
             self._write_protect.disable()
             try:
-                self.reset()
+                self._blank_and_verify()
                 self._eepflash_write(image)
             finally:
                 self._write_protect.enable()
@@ -288,32 +292,36 @@ class EEPROM:
         """
         self._require_detected()
 
-        blank = self._workdir / "blank.eep"
-        blank_readback = self._workdir / "blank_readback.eep"
-
         try:
             self._write_protect.disable()
-
-            # Create blank binary
-            blank.write_bytes(b"\x00" * (self._config.size_kbytes * 1024))
-
-            # Write blank to EEPROM
-            self._eepflash_write(blank)
-            time.sleep(0.5)
-
-            # Read back and verify
-            self._eepflash_read(blank_readback)
-            content = blank_readback.read_bytes()
-            if any(byte != 0 for byte in content):
-                raise EEPROMWriteError("EEPROM verification failed — not blank")
-
-            logger.info("EEPROM successfully blanked and verified")
+            try:
+                self._blank_and_verify()
+            finally:
+                self._write_protect.enable()
         except EEPROMWriteError:
             raise
         except (subprocess.CalledProcessError, OSError) as e:
             raise EEPROMWriteError(f"Failed to reset EEPROM: {e}") from e
-        finally:
-            self._write_protect.enable()
+
+    def _blank_and_verify(self) -> None:
+        """Write zeros to the EEPROM and verify. Caller must manage write-protect."""
+        blank = self._workdir / "blank.eep"
+        blank_readback = self._workdir / "blank_readback.eep"
+
+        # Create blank binary
+        blank.write_bytes(b"\x00" * (self._config.size_kbytes * 1024))
+
+        # Write blank to EEPROM
+        self._eepflash_write(blank)
+        time.sleep(0.5)
+
+        # Read back and verify
+        self._eepflash_read(blank_readback)
+        content = blank_readback.read_bytes()
+        if any(byte != 0 for byte in content):
+            raise EEPROMWriteError("EEPROM verification failed — not blank")
+
+        logger.info("EEPROM successfully blanked and verified")
 
     @staticmethod
     def generate_serial_number(length: int = 12) -> str:

--- a/src/rpi_eeprom/_eeprom.py
+++ b/src/rpi_eeprom/_eeprom.py
@@ -93,7 +93,8 @@ class EEPROM:
         self.close()
 
     def close(self) -> None:
-        """Clean up temporary files and tool resources."""
+        """Clean up temporary files, tool resources, and GPIO pins."""
+        self._write_protect.close()
         self._tools.close()
         self._tmpdir.cleanup()
 

--- a/src/rpi_eeprom/_gpio.py
+++ b/src/rpi_eeprom/_gpio.py
@@ -22,6 +22,10 @@ class WriteProtect(Protocol):
         """Disable write protection (pin LOW)."""
         ...
 
+    def close(self) -> None:
+        """Release underlying resources (e.g. GPIO pin reservation)."""
+        ...
+
 
 class GPIOWriteProtect:
     """Real GPIO write-protect using gpiozero."""
@@ -36,6 +40,9 @@ class GPIOWriteProtect:
 
     def disable(self) -> None:
         self._device.off()
+
+    def close(self) -> None:
+        self._device.close()
 
 
 class MockWriteProtect:
@@ -53,6 +60,9 @@ class MockWriteProtect:
     def disable(self) -> None:
         self._enabled = False
         logger.debug("Mock write-protect disabled (pin %d)", self.pin)
+
+    def close(self) -> None:
+        self._enabled = False
 
 
 def _is_raspberry_pi() -> bool:

--- a/src/rpi_eeprom/_vendor/templates/eeprom_settings.txt
+++ b/src/rpi_eeprom/_vendor/templates/eeprom_settings.txt
@@ -6,3 +6,14 @@ product_id 0x0000
 product_ver 0x0001
 vendor "Ubopod"
 product "RPi HAT"
+
+# GPIO bank 0 — required by eepmake for HAT V1 format
+# drive, slew, hysteresis apply to all pins in the bank
+gpio_drive 0
+gpio_slew 0
+gpio_hysteresis 0
+back_power 0
+
+# setgpio <GPIO#> <fsel> <pull>
+# fsel: INPUT=0, OUTPUT=1, ALT0-ALT5=4,5,6,7,3,2
+# pull: DEFAULT=0, UP=1, DOWN=2, NONE=3

--- a/tests/test_e2e_hardware.py
+++ b/tests/test_e2e_hardware.py
@@ -10,6 +10,7 @@ Run on a Raspberry Pi with an EEPROM attached::
 Prerequisites:
     - I2C overlay loaded: sudo dtoverlay i2c-gpio i2c_gpio_sda=0 i2c_gpio_scl=1 bus=9
     - eepmake, eepdump, eepflash.sh installed or bundled
+    - gpiozero installed: pip install rpi-eeprom[gpio]
     - sudo access (eepflash.sh requires it)
 """
 
@@ -20,6 +21,7 @@ from collections.abc import Generator
 import pytest
 
 from rpi_eeprom import EEPROM, EEPROMConfig
+from rpi_eeprom._gpio import MockWriteProtect
 from rpi_eeprom._tools import detect_i2c
 
 # Default hardware configuration — adjust if your setup differs
@@ -48,6 +50,12 @@ pytestmark = [
 def eeprom() -> Generator[EEPROM]:
     """Provide an EEPROM instance connected to real hardware."""
     with EEPROM(_HW_CONFIG) as e:
+        if isinstance(e._write_protect, MockWriteProtect):
+            pytest.fail(
+                "gpiozero is not installed — write-protect pin cannot be "
+                "toggled, so EEPROM writes will fail. "
+                "Install with: pip install rpi-eeprom[gpio]"
+            )
         yield e
 
 

--- a/tests/test_e2e_hardware.py
+++ b/tests/test_e2e_hardware.py
@@ -1,0 +1,183 @@
+"""End-to-end hardware tests for EEPROM read/write on a real Raspberry Pi.
+
+These tests interact with a physical EEPROM chip over I2C. They are skipped
+automatically when no EEPROM is detected (i.e. on dev machines and in CI).
+
+Run on a Raspberry Pi with an EEPROM attached::
+
+    sudo pytest tests/test_e2e_hardware.py -v -m hardware
+
+Prerequisites:
+    - I2C overlay loaded: sudo dtoverlay i2c-gpio i2c_gpio_sda=0 i2c_gpio_scl=1 bus=9
+    - eepmake, eepdump, eepflash.sh installed or bundled
+    - sudo access (eepflash.sh requires it)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+
+from rpi_eeprom import EEPROM, EEPROMConfig
+from rpi_eeprom._tools import detect_i2c
+
+# Default hardware configuration — adjust if your setup differs
+_HW_CONFIG = EEPROMConfig()
+
+
+def _hardware_available() -> bool:
+    """Check if an EEPROM is reachable on the default I2C bus."""
+    try:
+        return detect_i2c(_HW_CONFIG.i2c_bus, _HW_CONFIG.i2c_address)
+    except Exception:
+        return False
+
+
+# Skip the entire module when no hardware is present
+pytestmark = [
+    pytest.mark.hardware,
+    pytest.mark.skipif(
+        not _hardware_available(),
+        reason="No EEPROM detected — skipping hardware tests",
+    ),
+]
+
+
+@pytest.fixture
+def eeprom() -> Generator[EEPROM]:
+    """Provide an EEPROM instance connected to real hardware."""
+    with EEPROM(_HW_CONFIG) as e:
+        yield e
+
+
+class TestHardwareDetect:
+    """Verify the device is actually detected."""
+
+    def test_detect_returns_true(self, eeprom: EEPROM) -> None:
+        assert eeprom.detect() is True
+
+
+class TestHardwareReset:
+    """Verify reset blanks the EEPROM."""
+
+    def test_reset_blanks_eeprom(self, eeprom: EEPROM) -> None:
+        eeprom.reset()
+        # After reset, read should fail because there is no valid HAT data
+        with pytest.raises(Exception):
+            eeprom.read()
+
+
+class TestHardwareWriteReadRoundTrip:
+    """Write known data, read it back, and verify it matches."""
+
+    def test_write_and_read_back(self, eeprom: EEPROM) -> None:
+        test_serial = f"E2E{EEPROM.generate_serial_number(8)}"
+        test_data = {
+            "serial_number": test_serial,
+            "test_marker": "e2e_hardware_test",
+            "version": 1,
+        }
+
+        # Write
+        eeprom.write(custom_data=[test_data])
+
+        # Read back
+        content = eeprom.read()
+
+        # Validate
+        assert content.serial_number == test_serial
+        assert len(content.custom_data) == 1
+        assert content.custom_data[0]["test_marker"] == "e2e_hardware_test"
+        assert content.custom_data[0]["version"] == 1
+        assert content.product_uuid != ""
+        assert content.product_uuid != "00000000-0000-0000-0000-000000000000"
+
+    def test_write_multiple_sections_and_read_back(
+        self, eeprom: EEPROM,
+    ) -> None:
+        section_0 = {"serial_number": f"E2E{EEPROM.generate_serial_number(8)}"}
+        section_1 = {"extra_key": "extra_value", "count": 42}
+
+        eeprom.write(custom_data=[section_0, section_1])
+
+        content = eeprom.read()
+        assert len(content.custom_data) == 2
+        assert content.custom_data[0]["serial_number"] == section_0["serial_number"]
+        assert content.custom_data[1]["extra_key"] == "extra_value"
+        assert content.custom_data[1]["count"] == 42
+
+
+class TestHardwareUpdate:
+    """Test update operations that preserve UUID while changing custom data."""
+
+    def test_update_preserves_uuid(self, eeprom: EEPROM) -> None:
+        # Initial write
+        original_serial = f"E2E{EEPROM.generate_serial_number(8)}"
+        eeprom.write(custom_data=[{"serial_number": original_serial}])
+        original = eeprom.read()
+
+        # Update with new custom data
+        new_serial = f"E2E{EEPROM.generate_serial_number(8)}"
+        eeprom.update(custom_data=[{"serial_number": new_serial}])
+        updated = eeprom.read()
+
+        # UUID should be preserved, serial should change
+        assert updated.product_uuid == original.product_uuid
+        assert updated.serial_number == new_serial
+        assert updated.serial_number != original_serial
+
+    def test_update_append(self, eeprom: EEPROM) -> None:
+        # Initial write with one section
+        serial = f"E2E{EEPROM.generate_serial_number(8)}"
+        eeprom.write(custom_data=[{"serial_number": serial}])
+
+        # Append a second section
+        eeprom.update(custom_data=[{"appended": True}], append=True)
+        content = eeprom.read()
+
+        assert len(content.custom_data) == 2
+        assert content.custom_data[0]["serial_number"] == serial
+        assert content.custom_data[1]["appended"] is True
+
+
+class TestHardwareFullCycle:
+    """Full end-to-end cycle: detect -> write -> read -> update -> read -> reset."""
+
+    def test_full_lifecycle(self, eeprom: EEPROM) -> None:
+        # 1. Detect
+        assert eeprom.detect() is True
+
+        # 2. Write initial data
+        serial = f"E2E{EEPROM.generate_serial_number(8)}"
+        eeprom.write(custom_data=[{
+            "serial_number": serial,
+            "lifecycle_test": True,
+        }])
+
+        # 3. Read back and validate
+        content = eeprom.read()
+        assert content.serial_number == serial
+        assert content.custom_data[0]["lifecycle_test"] is True
+        original_uuid = content.product_uuid
+
+        # 4. Update — replace custom data, UUID preserved
+        new_serial = f"E2E{EEPROM.generate_serial_number(8)}"
+        eeprom.update(custom_data=[{
+            "serial_number": new_serial,
+            "lifecycle_test": True,
+            "updated": True,
+        }])
+
+        # 5. Read back updated content
+        updated = eeprom.read()
+        assert updated.product_uuid == original_uuid
+        assert updated.serial_number == new_serial
+        assert updated.custom_data[0]["updated"] is True
+
+        # 6. Reset to blank
+        eeprom.reset()
+
+        # 7. Verify blank — read should fail on a blanked EEPROM
+        with pytest.raises(Exception):
+            eeprom.read()


### PR DESCRIPTION
This pull request introduces comprehensive support for end-to-end hardware testing of EEPROM operations on a Raspberry Pi, improves resource management for GPIO write-protect handling, and refactors EEPROM blanking logic for clarity and reliability. It also updates documentation to guide users through hardware test setup and configuration.

Hardware testing support:

* Added a new `tests/test_e2e_hardware.py` suite for end-to-end EEPROM tests on real hardware, including detection, blanking, write/read, update, and full lifecycle scenarios. Tests are skipped automatically if no EEPROM is detected, and require explicit opt-in.
* Updated `README.md` with detailed instructions for running hardware tests, prerequisites, warnings about EEPROM erasure, and custom hardware configuration guidance.
* Configured pytest to recognize a `hardware` marker and exclude hardware tests by default unless explicitly enabled.

Resource management improvements:

* Added a `close()` method to GPIO write-protect classes (`GPIOWriteProtect`, `MockWriteProtect`) and ensured it is called during EEPROM cleanup to release GPIO resources properly. [[1]](diffhunk://#diff-06fae31b4a094ec81290f9556bc1b0e35cb38ef28991fcdb67ebb46ad9af7d7aR25-R28) [[2]](diffhunk://#diff-06fae31b4a094ec81290f9556bc1b0e35cb38ef28991fcdb67ebb46ad9af7d7aR44-R46) [[3]](diffhunk://#diff-06fae31b4a094ec81290f9556bc1b0e35cb38ef28991fcdb67ebb46ad9af7d7aR64-R66) [[4]](diffhunk://#diff-264dff6f71a645cfe0cea80bd9be8e9ae12b954f43c1f484f30850b9ecdda746L96-R97)

EEPROM blanking and write-protect refactoring:

* Refactored EEPROM blanking logic by extracting `_blank_and_verify()` from `reset()`, ensuring write-protect is disabled only during blanking and re-enabled reliably. This pattern is now used in `write()`, `update()`, and `reset()` methods for safer hardware operations. [[1]](diffhunk://#diff-264dff6f71a645cfe0cea80bd9be8e9ae12b954f43c1f484f30850b9ecdda746L199-R206) [[2]](diffhunk://#diff-264dff6f71a645cfe0cea80bd9be8e9ae12b954f43c1f484f30850b9ecdda746L271-R276) [[3]](diffhunk://#diff-264dff6f71a645cfe0cea80bd9be8e9ae12b954f43c1f484f30850b9ecdda746L290-R309) [[4]](diffhunk://#diff-264dff6f71a645cfe0cea80bd9be8e9ae12b954f43c1f484f30850b9ecdda746L310-L315)

Documentation and template updates:

* Clarified test instructions in `README.md` for unit tests (no hardware required).
* Updated the EEPROM settings template to include required GPIO bank configuration for HAT V1 format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Hardware end-to-end testing capability with automatic EEPROM detection
  * New GPIO configuration parameters for HAT EEPROM settings

* **Documentation**
  * Comprehensive hardware test guide with prerequisites and setup instructions

* **Tests**
  * Full hardware test suite validating EEPROM detect, read, write, update, and reset operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->